### PR TITLE
商品表示一覧機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,4 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
+gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -161,6 +162,11 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.0)
       stringio
     public_suffix (5.0.3)
@@ -303,6 +309,7 @@ DEPENDENCIES
   mini_magick
   mysql2 (~> 0.5)
   pg
+  pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)
   rspec-rails

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index 
-    
+    @items = Item.order(created_at: :desc)
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -111,7 +111,7 @@
       <%# ダミー商品を表示する %>
       <% if @items.nil? || @items.empty? %>
         <li class="list">
-          <a href="#">
+          <%= link_to '#' do %>
             <div class="item-img-content">
               <%= image_tag("item-sample.png", class:"item-img") %>
             </div>
@@ -122,17 +122,18 @@
               <div class="item-price">
                 <span>10000円<br>着払い(購入者負担)</span>
                 <div class="star-btn">
-                  <%= link_to image_tag("star.png", class:"star-icon") %>
+                  <%= image_tag("star.png", class:"star-icon") %>
                   <span class="star-count">0</span>
                 </div>
               </div>
             </div>
-          </a>
+          <% end %>
         </li>
       <% else %>
+        <%# 商品の一覧を表示 %>
         <% @items.each do |item| %>
           <li class="list">
-            <a href="#">
+            <%= link_to '#' do %>
               <div class="item-img-content">
                 <%= image_tag item.image, class: 'item-img' %>
               </div>
@@ -143,12 +144,12 @@
                 <div class="item-price">
                   <span><%= item.price %>円<br><%= Deliverycost.find(item.delivery_cost_id).name %></span>
                   <div class="star-btn">
-                    <%= link_to image_tag("star.png", class:"star-icon") %>
+                    <%= image_tag("star.png", class:"star-icon") %>
                     <span class="star-count">0</span>
                   </div>
                 </div>
               </div>
-            </a>
+            <% end %>
           </li>
         <% end %>
       <% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -107,6 +107,52 @@
     <div class="subtitle">
       新規投稿商品
     </div>
+    <ul class="item-lists">
+      <%# ダミー商品を表示する %>
+      <% if @items.nil? || @items.empty? %>
+        <li class="list">
+          <a href="#">
+            <div class="item-img-content">
+              <%= image_tag("item-sample.png", class:"item-img") %>
+            </div>
+            <div class="item-info">
+              <h3 class="item-name">
+                ダミー商品
+              </h3>
+              <div class="item-price">
+                <span>10000円<br>着払い(購入者負担)</span>
+                <div class="star-btn">
+                  <%= link_to image_tag("star.png", class:"star-icon") %>
+                  <span class="star-count">0</span>
+                </div>
+              </div>
+            </div>
+          </a>
+        </li>
+      <% else %>
+        <% @items.each do |item| %>
+          <li class="list">
+            <a href="#">
+              <div class="item-img-content">
+                <%= image_tag item.image, class: 'item-img' %>
+              </div>
+              <div class="item-info">
+                <h3 class="item-name">
+                  <%= item.product_name %>
+                </h3>
+                <div class="item-price">
+                  <span><%= item.price %>円<br><%= Deliverycost.find(item.delivery_cost_id).name %></span>
+                  <div class="star-btn">
+                    <%= link_to image_tag("star.png", class:"star-icon") %>
+                    <span class="star-count">0</span>
+                  </div>
+                </div>
+              </div>
+            </a>
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
   </div>
 </div>
 

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     prefecture_id { Faker::Number.between(from: 2, to: 48) }
     days_until_send_id { Faker::Number.between(from: 2, to: 4) }
     price { Faker::Number.between(from: 300, to: 9_999_999) }
+
     association :user
 
     after(:build) do |item|


### PR DESCRIPTION
what
・現在出品されている商品を一覧できる機能をトップページに実装した。
・商品画像、商品名、価格、配送料の負担先、についての情報を表示できる。

why
・商品情報を一覧できることが目的のため、ユーザーがログインしているかどうかにかかわらず、商品表示される。
・登録された商品情報が存在しない場合、見本となるダミーの商品情報が表示される。

以下、動作確認用のgyazoURL

商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/d2b6dc8444fc8a88f16509a2da21d491

商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/05a31548b1c0df5d9d2586ce8913bb52
